### PR TITLE
httputil: Add a package for common http code.

### DIFF
--- a/httputil/README.md
+++ b/httputil/README.md
@@ -1,0 +1,13 @@
+httputil
+====
+
+Common code for dealing with HTTP.
+
+Includes:
+
+* Code for returning JSON responses.
+
+### Documentation
+
+Visit the docs on [gopkgdoc](http://godoc.org/github.com/coreos/pkg/httputil)
+

--- a/httputil/json.go
+++ b/httputil/json.go
@@ -1,0 +1,27 @@
+package httputil
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const (
+	JSONContentType = "application/json"
+)
+
+func WriteJSONResponse(w http.ResponseWriter, code int, resp interface{}) error {
+	enc, err := json.Marshal(resp)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return err
+	}
+
+	w.Header().Set("Content-Type", JSONContentType)
+	w.WriteHeader(code)
+
+	_, err = w.Write(enc)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/httputil/json_test.go
+++ b/httputil/json_test.go
@@ -1,0 +1,56 @@
+package httputil
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteJSONResponse(t *testing.T) {
+	for i, test := range []struct {
+		code         int
+		resp         interface{}
+		expectedJSON string
+		expectErr    bool
+	}{
+		{
+			200,
+			struct {
+				A string
+				B string
+			}{A: "foo", B: "bar"},
+			`{"A":"foo","B":"bar"}`,
+			false,
+		},
+		{
+			500,
+			// Something that json.Marshal cannot serialize.
+			make(chan int),
+			"",
+			true,
+		},
+	} {
+		w := httptest.NewRecorder()
+		err := WriteJSONResponse(w, test.code, test.resp)
+
+		if w.Code != test.code {
+			t.Errorf("case %d: w.code == %v, want %v", i, w.Code, test.code)
+		}
+
+		if (err != nil) != test.expectErr {
+			t.Errorf("case %d: (err != nil) == %v, want %v. err: %v", i, err != nil, test.expectErr, err)
+		}
+
+		if string(w.Body.Bytes()) != test.expectedJSON {
+			t.Errorf("case %d: w.Body.Bytes()) == %q, want %q", i,
+				string(w.Body.Bytes()), test.expectedJSON)
+		}
+
+		if !test.expectErr {
+			contentType := w.Header()["Content-Type"][0]
+			if contentType != JSONContentType {
+				t.Errorf("case %d: contentType == %v, want %v", i, contentType, JSONContentType)
+			}
+		}
+	}
+
+}

--- a/test
+++ b/test
@@ -14,7 +14,7 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE="cryptoutil flagutil timeutil netutil yamlutil"
+TESTABLE="cryptoutil flagutil timeutil netutil yamlutil httputil"
 FORMATTABLE="$TESTABLE log"
 
 # user has not provided PKG override


### PR DESCRIPTION
* Allows other projects to easily add a health-check endpoint with
  custom checks.
* Health code is mostly cribbed from coreos-inc/auth/pkg health; once
  this has landed we can remove that and have it depend on this instead
* Also started an HTTPUtil which right now just has a method for writing
  JSON responses.