### PR TITLE
health: add health-checking package.

### DIFF
--- a/health/README.md
+++ b/health/README.md
@@ -1,0 +1,11 @@
+health
+====
+
+A simple framework for implementing an HTTP health check endpoint on servers.
+
+Users implement their `health.Checkable` types, and create a `health.Checker`, from which they can get an `http.HandlerFunc` using `health.Checker.MakeHealthHandlerFunc`.
+
+### Documentation
+
+For more details, visit the docs on [gopkgdoc](http://godoc.org/github.com/coreos/pkg/health)
+

--- a/health/health.go
+++ b/health/health.go
@@ -1,0 +1,114 @@
+package health
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/coreos/pkg/httputil"
+)
+
+// Checkables should return nil when the thing they are checking is healthy, and an error otherwise.
+type Checkable interface {
+	Healthy() error
+}
+
+// Checker provides a way to make an endpoint which can be probed for system health.
+type Checker struct {
+	// Checks are the Checkables to be checked when probing.
+	Checks []Checkable
+
+	// Unhealthyhandler is called when one or more of the checks are unhealthy.
+	// If not provided DefaultUnhealthyHandler is called.
+	UnhealthyHandler UnhealthyHandler
+
+	// HealthyHandler is called when all checks are healthy.
+	// If not provided, DefaultHealthyHandler is called.
+	HealthyHandler http.HandlerFunc
+}
+
+// MakeHealthHandlerFunc returns an http.HandlerFunc which can be probed for system health.
+func (c Checker) MakeHealthHandlerFunc() http.HandlerFunc {
+	unhealthyHandler := c.UnhealthyHandler
+	if unhealthyHandler == nil {
+		unhealthyHandler = DefaultUnhealthyHandler
+	}
+
+	successHandler := c.HealthyHandler
+	if successHandler == nil {
+		successHandler = DefaultHealthyHandler
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			w.Header().Set("Allow", "GET")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		if err := Check(c.Checks); err != nil {
+			unhealthyHandler(w, r, err)
+			return
+		}
+
+		successHandler(w, r)
+	}
+}
+
+type UnhealthyHandler func(w http.ResponseWriter, r *http.Request, err error)
+
+type StatusResponse struct {
+	Status  string                 `json:"status"`
+	Details *StatusResponseDetails `json:"details,omitempty"`
+}
+
+type StatusResponseDetails struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func Check(checks []Checkable) (err error) {
+	errs := []error{}
+	for _, c := range checks {
+		if e := c.Healthy(); e != nil {
+			errs = append(errs, e)
+		}
+	}
+
+	switch len(errs) {
+	case 0:
+		err = nil
+	case 1:
+		err = errs[0]
+	default:
+		err = fmt.Errorf("multiple health check failure: %v", errs)
+	}
+
+	return
+}
+
+func DefaultHealthyHandler(w http.ResponseWriter, r *http.Request) {
+	err := httputil.WriteJSONResponse(w, http.StatusOK, StatusResponse{
+		Status: "ok",
+	})
+	if err != nil {
+		// TODO(bobbyrullo): replace with logging from new logging pkg,
+		// once it lands.
+		log.Printf("Failed to write JSON response: %v", err)
+	}
+}
+
+func DefaultUnhealthyHandler(w http.ResponseWriter, r *http.Request, err error) {
+	writeErr := httputil.WriteJSONResponse(w, http.StatusInternalServerError, StatusResponse{
+		Status: "error",
+		Details: &StatusResponseDetails{
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		},
+	})
+	if writeErr != nil {
+		// TODO(bobbyrullo): replace with logging from new logging pkg,
+		// once it lands.
+		log.Printf("Failed to write JSON response: %v", err)
+	}
+}

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -1,0 +1,198 @@
+package health
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coreos/pkg/httputil"
+)
+
+type boolChecker bool
+
+func (b boolChecker) Healthy() error {
+	if b {
+		return nil
+	}
+	return errors.New("Unhealthy")
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func TestCheck(t *testing.T) {
+	for i, test := range []struct {
+		checks   []Checkable
+		expected string
+	}{
+		{[]Checkable{}, ""},
+
+		{[]Checkable{boolChecker(true)}, ""},
+
+		{[]Checkable{boolChecker(true), boolChecker(true)}, ""},
+
+		{[]Checkable{boolChecker(true), boolChecker(false)}, "Unhealthy"},
+
+		{[]Checkable{boolChecker(true), boolChecker(false), boolChecker(false)}, "multiple health check failure: [Unhealthy Unhealthy]"},
+	} {
+		err := Check(test.checks)
+
+		if errString(err) != test.expected {
+			t.Errorf("case %d: want %v, got %v", i, test.expected, errString(err))
+		}
+	}
+}
+
+func TestHandlerFunc(t *testing.T) {
+	for i, test := range []struct {
+		checker         Checker
+		method          string
+		expectedStatus  string
+		expectedCode    int
+		expectedMessage string
+	}{
+		{
+			Checker{
+				Checks: []Checkable{
+					boolChecker(true),
+				},
+			},
+			"GET",
+			"ok",
+			http.StatusOK,
+			"",
+		},
+
+		// Wrong method.
+		{
+			Checker{
+				Checks: []Checkable{
+					boolChecker(true),
+				},
+			},
+			"POST",
+			"",
+			http.StatusMethodNotAllowed,
+			"GET only acceptable method",
+		},
+
+		// Health check fails.
+		{
+			Checker{
+				Checks: []Checkable{
+					boolChecker(false),
+				},
+			},
+			"GET",
+			"error",
+			http.StatusInternalServerError,
+			"Unhealthy",
+		},
+
+		// Health check fails, with overridden ErrorHandler.
+		{
+			Checker{
+				Checks: []Checkable{
+					boolChecker(false),
+				},
+				UnhealthyHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+					httputil.WriteJSONResponse(w,
+						http.StatusInternalServerError, StatusResponse{
+							Status: "error",
+							Details: &StatusResponseDetails{
+								Code:    http.StatusInternalServerError,
+								Message: "Override!",
+							},
+						})
+				},
+			},
+			"GET",
+			"error",
+			http.StatusInternalServerError,
+			"Override!",
+		},
+
+		// Health check succeeds, with overridden SuccessHandler.
+		{
+			Checker{
+				Checks: []Checkable{
+					boolChecker(true),
+				},
+				HealthyHandler: func(w http.ResponseWriter, r *http.Request) {
+					httputil.WriteJSONResponse(w,
+						http.StatusOK, StatusResponse{
+							Status: "okey-dokey",
+						})
+				},
+			},
+			"GET",
+			"okey-dokey",
+			http.StatusOK,
+			"",
+		},
+	} {
+		w := httptest.NewRecorder()
+		r := &http.Request{}
+		r.Method = test.method
+		test.checker.MakeHealthHandlerFunc()(w, r)
+		if w.Code != test.expectedCode {
+			t.Errorf("case %d: w.code == %v, want %v", i, w.Code, test.expectedCode)
+		}
+
+		if test.expectedStatus == "" {
+			// This is to handle the wrong-method case, when the
+			// body of the response is empty.
+			continue
+		}
+
+		statusMap := make(map[string]interface{})
+		err := json.Unmarshal(w.Body.Bytes(), &statusMap)
+		if err != nil {
+			t.Fatalf("case %d: failed to Unmarshal response body: %v", i, err)
+		}
+
+		status, ok := statusMap["status"].(string)
+		if !ok {
+			t.Errorf("case %d: status not present or not a string in json: %q", i, w.Body.Bytes())
+		}
+		if status != test.expectedStatus {
+			t.Errorf("case %d: status == %v, want %v", i, status, test.expectedStatus)
+		}
+
+		detailMap, ok := statusMap["details"].(map[string]interface{})
+		if test.expectedMessage != "" {
+			if !ok {
+				t.Fatalf("case %d: could not find/unmarshal detailMap", i)
+			}
+			message, ok := detailMap["message"].(string)
+			if !ok {
+				t.Fatalf("case %d: message not present or not a string in json: %q",
+					i, w.Body.Bytes())
+			}
+			if message != test.expectedMessage {
+				t.Errorf("case %d: message == %v, want %v", i, message, test.expectedMessage)
+			}
+
+			code, ok := detailMap["code"].(float64)
+			if !ok {
+				t.Fatalf("case %d: code not present or not an int in json: %q",
+					i, w.Body.Bytes())
+			}
+			if int(code) != test.expectedCode {
+				t.Errorf("case %d: code == %v, want %v", i, code, test.expectedCode)
+			}
+
+		} else {
+			if ok {
+				t.Errorf("case %d: unwanted detailMap present: %q", i, detailMap)
+			}
+		}
+
+	}
+}

--- a/test
+++ b/test
@@ -14,7 +14,7 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE="cryptoutil flagutil timeutil netutil yamlutil httputil"
+TESTABLE="cryptoutil flagutil timeutil netutil yamlutil httputil health"
 FORMATTABLE="$TESTABLE log"
 
 # user has not provided PKG override


### PR DESCRIPTION
* Allows other projects to easily add a health-check endpoint with
  custom checks.
* Health code is mostly cribbed from coreos-inc/auth/pkg health; once
  this has landed we can remove that and have it depend on this instead.