### PR TITLE
capnslog: support setting LogLevel via command line flags

### DIFF
--- a/capnslog/example/hello_dolly.go
+++ b/capnslog/example/hello_dolly.go
@@ -1,27 +1,34 @@
 package main
 
 import (
+	"flag"
 	oldlog "log"
 	"os"
 
 	"github.com/coreos/pkg/capnslog"
 )
 
+var logLevel = capnslog.INFO
 var log = capnslog.NewPackageLogger("github.com/coreos/pkg/capnslog/cmd", "main")
 var dlog = capnslog.NewPackageLogger("github.com/coreos/pkg/capnslog/cmd", "dolly")
+
+func init() {
+	flag.Var(&logLevel, "log-level", "Global log level.")
+}
 
 func main() {
 	rl := capnslog.MustRepoLogger("github.com/coreos/pkg/capnslog/cmd")
 	capnslog.SetFormatter(capnslog.NewStringFormatter(os.Stderr))
 
 	// We can parse the log level configs from the command line
-	if len(os.Args) > 1 {
-		cfg, err := rl.ParseLogLevelConfig(os.Args[1])
+	flag.Parse()
+	if flag.NArg() > 1 {
+		cfg, err := rl.ParseLogLevelConfig(flag.Arg(1))
 		if err != nil {
 			log.Fatal(err)
 		}
 		rl.SetLogLevel(cfg)
-		log.Infof("Setting output to %s", os.Args[1])
+		log.Infof("Setting output to %s", flag.Arg(1))
 	}
 
 	// Send some messages at different levels to the different packages
@@ -32,7 +39,7 @@ func main() {
 	dlog.Tracef("I can tell, Dolly")
 
 	// We also have control over the built-in "log" package.
-	capnslog.SetGlobalLogLevel(capnslog.INFO)
+	capnslog.SetGlobalLogLevel(logLevel)
 	oldlog.Println("You're still glowin', you're still crowin', you're still lookin' strong")
 	log.Fatalf("Dolly'll never go away again")
 }

--- a/capnslog/logmap.go
+++ b/capnslog/logmap.go
@@ -11,19 +11,19 @@ type LogLevel int8
 
 const (
 	// CRITICAL is the lowest log level; only errors which will end the program will be propagated.
-	CRITICAL LogLevel = -1
+	CRITICAL LogLevel = iota - 1
 	// ERROR is for errors that are not fatal but lead to troubling behavior.
-	ERROR = 0
+	ERROR
 	// WARNING is for errors which are not fatal and not errors, but are unusual. Often sourced from misconfigurations.
-	WARNING = 1
+	WARNING
 	// NOTICE is for normal but significant conditions.
-	NOTICE = 2
+	NOTICE
 	// INFO is a log level for common, everyday log updates.
-	INFO = 3
+	INFO
 	// DEBUG is the default hidden level for more verbose updates about internal processes.
-	DEBUG = 4
+	DEBUG
 	// TRACE is for (potentially) call by call tracing of programs.
-	TRACE = 5
+	TRACE
 )
 
 // Char returns a single-character representation of the log level.

--- a/capnslog/logmap.go
+++ b/capnslog/logmap.go
@@ -48,6 +48,39 @@ func (l LogLevel) Char() string {
 	}
 }
 
+// String returns a multi-character representation of the log level.
+func (l LogLevel) String() string {
+	switch l {
+	case CRITICAL:
+		return "CRITICAL"
+	case ERROR:
+		return "ERROR"
+	case WARNING:
+		return "WARNING"
+	case NOTICE:
+		return "NOTICE"
+	case INFO:
+		return "INFO"
+	case DEBUG:
+		return "DEBUG"
+	case TRACE:
+		return "TRACE"
+	default:
+		panic("Unhandled loglevel")
+	}
+}
+
+// Update using the given string value. Fulfills the flag.Value interface.
+func (l *LogLevel) Set(s string) error {
+	value, err := ParseLevel(s)
+	if err != nil {
+		return err
+	}
+
+	*l = value
+	return nil
+}
+
 // ParseLevel translates some potential loglevel strings into their corresponding levels.
 func ParseLevel(s string) (LogLevel, error) {
 	switch s {


### PR DESCRIPTION
LogLevel now fulfills the flag.Value interface and example updated.

    ./example -log-level=NOTICE