### PR TITLE
capnslog: remove useless BaseLogEntry type

### DIFF
--- a/capnslog/log_hijack.go
+++ b/capnslog/log_hijack.go
@@ -20,6 +20,6 @@ func (p packageWriter) Write(b []byte) (int, error) {
 	if p.pl.level < INFO {
 		return 0, nil
 	}
-	p.pl.internalLog(calldepth+2, INFO, BaseLogEntry(string(b)))
+	p.pl.internalLog(calldepth+2, INFO, string(b))
 	return len(b), nil
 }

--- a/capnslog/logmap.go
+++ b/capnslog/logmap.go
@@ -191,9 +191,3 @@ func NewPackageLogger(repo string, pkg string) (p *PackageLogger) {
 	}
 	return
 }
-
-type BaseLogEntry string
-
-func (b BaseLogEntry) LogString() string {
-	return string(b)
-}

--- a/capnslog/pkg_logger.go
+++ b/capnslog/pkg_logger.go
@@ -30,15 +30,15 @@ func (p *PackageLogger) LevelAt(l LogLevel) bool {
 // log stdlib compatibility
 
 func (p *PackageLogger) Println(args ...interface{}) {
-	p.internalLog(calldepth, INFO, BaseLogEntry(fmt.Sprintln(args...)))
+	p.internalLog(calldepth, INFO, fmt.Sprintln(args...))
 }
 
 func (p *PackageLogger) Printf(format string, args ...interface{}) {
-	p.internalLog(calldepth, INFO, BaseLogEntry(fmt.Sprintf(format, args...)))
+	p.internalLog(calldepth, INFO, fmt.Sprintf(format, args...))
 }
 
 func (p *PackageLogger) Print(args ...interface{}) {
-	p.internalLog(calldepth, INFO, BaseLogEntry(fmt.Sprint(args...)))
+	p.internalLog(calldepth, INFO, fmt.Sprint(args...))
 }
 
 // Panic and fatal


### PR DESCRIPTION
Commit cb18954f removed the LogEntry interface and most references to
its one implementation, BaseLogEntry. Finish the job.