### PR TITLE
capnslog: Set some defaults, propose a CoreOS formatter

### DIFF
--- a/capnslog/example/hello_dolly.go
+++ b/capnslog/example/hello_dolly.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	oldlog "log"
-	"os"
 
 	"github.com/coreos/pkg/capnslog"
 )
@@ -32,7 +31,6 @@ func init() {
 
 func main() {
 	rl := capnslog.MustRepoLogger("github.com/coreos/pkg/capnslog/cmd")
-	capnslog.SetFormatter(capnslog.NewStringFormatter(os.Stderr))
 
 	// We can parse the log level configs from the command line
 	flag.Parse()

--- a/capnslog/formatters.go
+++ b/capnslog/formatters.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -41,22 +42,65 @@ func (s *StringFormatter) Format(pkg string, l LogLevel, i int, entries ...inter
 	now := time.Now().UTC()
 	s.w.WriteString(now.Format(time.RFC3339))
 	s.w.WriteByte(' ')
-	s.writeEntries(pkg, l, i, entries...)
+	writeEntries(s.w, pkg, l, i, entries...)
+	s.Flush()
 }
 
-func (s *StringFormatter) writeEntries(pkg string, _ LogLevel, _ int, entries ...interface{}) {
+func writeEntries(w *bufio.Writer, pkg string, _ LogLevel, _ int, entries ...interface{}) {
 	if pkg != "" {
-		s.w.WriteString(pkg + ": ")
+		w.WriteString(pkg + ": ")
 	}
 	str := fmt.Sprint(entries...)
 	endsInNL := strings.HasSuffix(str, "\n")
-	s.w.WriteString(str)
+	w.WriteString(str)
 	if !endsInNL {
-		s.w.WriteString("\n")
+		w.WriteString("\n")
 	}
-	s.Flush()
 }
 
 func (s *StringFormatter) Flush() {
 	s.w.Flush()
+}
+
+func NewPrettyFormatter(w io.Writer, debug bool) Formatter {
+	return &PrettyFormatter{
+		w:     bufio.NewWriter(w),
+		debug: debug,
+	}
+}
+
+type PrettyFormatter struct {
+	w     *bufio.Writer
+	debug bool
+}
+
+func (c *PrettyFormatter) Format(pkg string, l LogLevel, depth int, entries ...interface{}) {
+	now := time.Now()
+	ts := now.Format("2006-01-02 15:04:05")
+	c.w.WriteString(ts)
+	ms := now.Nanosecond() / 1000
+	c.w.WriteString(fmt.Sprintf(".%06d", ms))
+	if c.debug {
+		_, file, line, ok := runtime.Caller(depth) // It's always the same number of frames to the user's call.
+		if !ok {
+			file = "???"
+			line = 1
+		} else {
+			slash := strings.LastIndex(file, "/")
+			if slash >= 0 {
+				file = file[slash+1:]
+			}
+		}
+		if line < 0 {
+			line = 0 // not a real line number
+		}
+		c.w.WriteString(fmt.Sprintf(" [%s:%d]", file, line))
+	}
+	c.w.WriteString(fmt.Sprint(" ", l.Char(), " | "))
+	writeEntries(c.w, pkg, l, depth, entries...)
+	c.Flush()
+}
+
+func (c *PrettyFormatter) Flush() {
+	c.w.Flush()
 }

--- a/capnslog/init.go
+++ b/capnslog/init.go
@@ -1,0 +1,47 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package capnslog
+
+import (
+	"io"
+	"os"
+	"syscall"
+)
+
+// Here's where the opinionation comes in. We need some sensible defaults,
+// especially after taking over the log package. Your project (whatever it may
+// be) may see things differently. That's okay; there should be no defaults in
+// the main package that cannot be controlled or overridden programatically,
+// otherwise it's a bug. Doing so is creating your own init_log.go file much
+// like this one.
+
+func init() {
+	initHijack()
+
+	// Go `log` pacakge uses os.Stderr.
+	SetFormatter(NewDefaultFormatter(os.Stderr))
+	SetGlobalLogLevel(INFO)
+}
+
+func NewDefaultFormatter(out io.Writer) Formatter {
+	if syscall.Getppid() == 1 {
+		// We're running under init, which may be systemd.
+		f, err := NewJournaldFormatter()
+		if err == nil {
+			return f
+		}
+	}
+	return NewPrettyFormatter(out, false)
+}

--- a/capnslog/journald_formatter.go
+++ b/capnslog/journald_formatter.go
@@ -1,0 +1,66 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +build !windows
+
+package capnslog
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/coreos/go-systemd/journal"
+)
+
+func NewJournaldFormatter() (Formatter, error) {
+	if !journal.Enabled() {
+		return nil, errors.New("No systemd detected")
+	}
+	return &journaldFormatter{}, nil
+}
+
+type journaldFormatter struct{}
+
+func (j *journaldFormatter) Format(pkg string, l LogLevel, _ int, entries ...interface{}) {
+	var pri journal.Priority
+	switch l {
+	case CRITICAL:
+		pri = journal.PriCrit
+	case ERROR:
+		pri = journal.PriErr
+	case WARNING:
+		pri = journal.PriWarning
+	case NOTICE:
+		pri = journal.PriNotice
+	case INFO:
+		pri = journal.PriInfo
+	case DEBUG:
+		pri = journal.PriDebug
+	case TRACE:
+		pri = journal.PriDebug
+	default:
+		panic("Unhandled loglevel")
+	}
+	msg := fmt.Sprint(entries...)
+	tags := map[string]string{
+		"PACKAGE": pkg,
+	}
+	err := journal.Send(msg, pri, tags)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+}
+
+func (j *journaldFormatter) Flush() {}

--- a/capnslog/log_hijack.go
+++ b/capnslog/log_hijack.go
@@ -18,7 +18,7 @@ import (
 	"log"
 )
 
-func init() {
+func initHijack() {
 	pkg := NewPackageLogger("log", "")
 	w := packageWriter{pkg}
 	log.SetFlags(0)

--- a/capnslog/pkg_logger.go
+++ b/capnslog/pkg_logger.go
@@ -24,7 +24,7 @@ type PackageLogger struct {
 	level LogLevel
 }
 
-const calldepth = 3
+const calldepth = 2
 
 func (p *PackageLogger) internalLog(depth int, inLevel LogLevel, entries ...interface{}) {
 	if inLevel != CRITICAL && p.level < inLevel {


### PR DESCRIPTION
Chasing #26. 

This is a little bold, but somebody's got to take a position and go for consensus. Here's some thoughts on sane defaults and a real CoreOS formatter.

The notion is as follows: we have a common log format, for which I'm proposing this:

```
    INFO | 2015-06-11 15:17:16.3707 | dolly: Hello Dolly
 WARNING | 2015-06-11 15:17:16.3707 | dolly: Well hello, Dolly
   ERROR | 2015-06-11 15:17:16.3707 | main: It's so nice to have you back where you belong
    INFO | 2015-06-11 15:17:16.3708 | You're still glowin', you're still crowin', you're still lookin' strong
CRITICAL | 2015-06-11 15:17:16.3708 | main: Dolly'll never go away again

```

But wait, there's more! A built-in debug flag to the CoreOS formatter yields the following:

```
    INFO | 2015-06-11 15:21:46.0527 [proc.go:63] | dolly: Hello Dolly
 WARNING | 2015-06-11 15:21:46.0528 [proc.go:63] | dolly: Well hello, Dolly
   ERROR | 2015-06-11 15:21:46.0528 [proc.go:63] | main: It's so nice to have you back where you belong
    INFO | 2015-06-11 15:21:46.0528 [proc.go:63] | You're still glowin', you're still crowin', you're still lookin' strong
CRITICAL | 2015-06-11 15:21:46.0528 [proc.go:63] | main: Dolly'll never go away again
```

The notion being that a new standard `--debug` flag for CoreOS apps can (a) drop the log level to debug or trace and (b) start tracing code lines (which is expensive in normal operation).

I designed the format for greppability and visual cues, without using ANSI color.