### PR TITLE
capnslog: set SYSLOG_IDENTIFIER for journal

### DIFF
--- a/capnslog/journald_formatter.go
+++ b/capnslog/journald_formatter.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/coreos/go-systemd/journal"
 )
@@ -55,7 +56,8 @@ func (j *journaldFormatter) Format(pkg string, l LogLevel, _ int, entries ...int
 	}
 	msg := fmt.Sprint(entries...)
 	tags := map[string]string{
-		"PACKAGE": pkg,
+		"PACKAGE":           pkg,
+		"SYSLOG_IDENTIFIER": filepath.Base(os.Args[0]),
 	}
 	err := journal.Send(msg, pri, tags)
 	if err != nil {


### PR DESCRIPTION
Fixes #40. I think it's reasonable to just set this by default rather than
needing to expose it to users.

References:
http://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html#SYSLOG_FACILITY=
http://linux.die.net/man/3/program_invocation_short_name