### PR TITLE
flagutil: Add SetFlagsFromEnvFile

### DIFF
--- a/flagutil/env_file.go
+++ b/flagutil/env_file.go
@@ -1,0 +1,77 @@
+package flagutil
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// SetFlagsFromEnvFile iterates the given flagset and if any flags are not
+// already set it attempts to set their values from the given env file. Env
+// files may have KEY=VALUE lines where the environment variable names are
+// in UPPERCASE, prefixed by the given PREFIX, and dashes are replaced by
+// underscores. For example, if prefix=PREFIX, some-flag is named
+// PREFIX_SOME_FLAG.
+// Comment lines are skipped, but more complex env file parsing is not
+// performed.
+func SetFlagsFromEnvFile(fs *flag.FlagSet, prefix string, path string) (err error) {
+	alreadySet := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) {
+		alreadySet[f.Name] = true
+	})
+	envs, err := parseEnvFile(path)
+	if err != nil {
+		return err
+	}
+	fs.VisitAll(func(f *flag.Flag) {
+		if !alreadySet[f.Name] {
+			key := prefix + "_" + strings.ToUpper(strings.Replace(f.Name, "-", "_", -1))
+			val := envs[key]
+			if val != "" {
+				if serr := fs.Set(f.Name, val); serr != nil {
+					err = fmt.Errorf("invalid value %q for %s: %v", val, key, serr)
+				}
+			}
+		}
+	})
+	return err
+}
+
+func parseEnvFile(path string) (map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	envs := make(map[string]string)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		token := scanner.Text()
+		if !skipLine(token) {
+			key, val, err := parseLine(token)
+			if err == nil {
+				envs[key] = val
+			}
+		}
+	}
+	return envs, nil
+}
+
+func skipLine(line string) bool {
+	return len(line) == 0 || strings.HasPrefix(line, "#")
+}
+
+func parseLine(line string) (key string, val string, err error) {
+	trimmed := strings.TrimSpace(line)
+	pair := strings.SplitN(trimmed, "=", 2)
+	if len(pair) != 2 {
+		err = fmt.Errorf("invalid KEY=value line: %q", line)
+		return
+	}
+	key = strings.TrimSpace(pair[0])
+	val = strings.TrimSpace(pair[1])
+	return
+}

--- a/flagutil/file_env_test.go
+++ b/flagutil/file_env_test.go
@@ -1,0 +1,107 @@
+package flagutil
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+var envFile = `
+# some secret env vars
+MYPROJ_A=foo		
+MYPROJ_C=woof
+`
+
+func TestSetFlagsFromEnvFile(t *testing.T) {
+	fs := flag.NewFlagSet("testing", flag.ExitOnError)
+	fs.String("a", "", "")
+	fs.String("b", "", "")
+	fs.String("c", "", "")
+	fs.Parse([]string{})
+
+	// add command-line flags
+	if err := fs.Set("b", "bar"); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Set("c", "quack"); err != nil {
+		t.Fatal(err)
+	}
+
+	// first verify that flags are as expected before reading the env
+	for f, want := range map[string]string{
+		"a": "",
+		"b": "bar",
+		"c": "quack",
+	} {
+		if got := fs.Lookup(f).Value.String(); got != want {
+			t.Fatalf("flag %q=%q, want %q", f, got, want)
+		}
+	}
+
+	file, err := ioutil.TempFile("", "env-file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+	file.Write([]byte(envFile))
+
+	// read env file and verify flags were updated as expected
+	err = SetFlagsFromEnvFile(fs, "MYPROJ", file.Name())
+	if err != nil {
+		t.Errorf("err=%v, want nil", err)
+	}
+	for f, want := range map[string]string{
+		"a": "foo",
+		"b": "bar",
+		"c": "quack",
+	} {
+		if got := fs.Lookup(f).Value.String(); got != want {
+			t.Errorf("flag %q=%q, want %q", f, got, want)
+		}
+	}
+}
+
+func TestSetFlagsFromEnvFile_FlagSetError(t *testing.T) {
+	// now verify that an error is propagated
+	fs := flag.NewFlagSet("testing", flag.ExitOnError)
+	fs.Int("x", 0, "")
+	file, err := ioutil.TempFile("", "env-file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+	file.Write([]byte("MYPROJ_X=not_a_number"))
+	if err := SetFlagsFromEnvFile(fs, "MYPROJ", file.Name()); err == nil {
+		t.Errorf("err=nil, want != nil")
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	cases := []struct {
+		line        string
+		expectedKey string
+		expectedVal string
+		nilErr      bool
+	}{
+		{"key=value", "key", "value", true},
+		{" key  =  value  	", "key", "value", true},
+		{"key='#gopher' #blah", "key", "'#gopher' #blah", true},
+		// invalid
+		{"key:value", "", "", false},
+		{"keyvalue", "", "", false},
+	}
+	for _, c := range cases {
+		key, val, err := parseLine(c.line)
+		if (err == nil) != c.nilErr {
+			if c.nilErr {
+				t.Errorf("got %s, want err=nil", err)
+			} else {
+				t.Errorf("got err=nil, want err!=nil")
+			}
+		}
+		if c.expectedKey != key || c.expectedVal != val {
+			t.Errorf("got %q=%q, want %q=%q", key, val, c.expectedKey, c.expectedVal)
+		}
+	}
+}


### PR DESCRIPTION
* Allow binaries to read from simple env var files so wrapper
script entrypoints aren't needed to source Kubernetes secret files

I've been wanting to improve upon using wrapper script entrypoints to source Kubernetes secrets files (deployment detail) in some projects, until Kubernetes environment variable secrets are supported. With `SetFlagsFromEnvFile` the binary is endowed with the ability to source variables from a file, typically set via `ENV_FILE` or `SECRETS_FILE`. Here's the change if others are also interested in this.