### PR TITLE
capnslog: add LogDepth to PackageLogger

### DIFF
--- a/capnslog/pkg_logger.go
+++ b/capnslog/pkg_logger.go
@@ -51,6 +51,11 @@ func (p *PackageLogger) Log(l LogLevel, args ...interface{}) {
 	p.internalLog(calldepth, l, fmt.Sprint(args...))
 }
 
+// Log a message at any level and with a given caller depth. Useful for wrapping capnslog.
+func (p *PackageLogger) LogDepth(depth int, l LogLevel, entries ...interface{}) {
+	p.internalLog(calldepth+depth, l, entries...)
+}
+
 // log stdlib compatibility
 
 func (p *PackageLogger) Println(args ...interface{}) {


### PR DESCRIPTION
I want to be able to wrap capnslog with convenience functions and application-specific helpers, but I need to be able to control the caller depth. This change makes that possible.