### PR TITLE
capnslog: fix small race on PackageLogger.level

### DIFF
--- a/capnslog/pkg_logger.go
+++ b/capnslog/pkg_logger.go
@@ -27,17 +27,19 @@ type PackageLogger struct {
 const calldepth = 2
 
 func (p *PackageLogger) internalLog(depth int, inLevel LogLevel, entries ...interface{}) {
+	logger.Lock()
+	defer logger.Unlock()
 	if inLevel != CRITICAL && p.level < inLevel {
 		return
 	}
-	logger.Lock()
-	defer logger.Unlock()
 	if logger.formatter != nil {
 		logger.formatter.Format(p.pkg, inLevel, depth+1, entries...)
 	}
 }
 
 func (p *PackageLogger) LevelAt(l LogLevel) bool {
+	logger.Lock()
+	defer logger.Unlock()
 	return p.level >= l
 }
 


### PR DESCRIPTION
```
WARNING: DATA RACE
Read by goroutine 46:
  github.com/coreos/pkg/capnslog.(*PackageLogger).internalLog()
      /home/mischief/code/go/src/github.com/coreos/pkg/capnslog/pkg_logger.go:30 +0x41
  github.com/coreos/pkg/capnslog.(*PackageLogger).Info()
      /home/mischief/code/go/src/github.com/coreos/pkg/capnslog/pkg_logger.go:131 +0x5a
...

Previous write by goroutine 44:
  github.com/coreos/pkg/capnslog.RepoLogger.setRepoLogLevelInternal()
      /home/mischief/code/go/src/github.com/coreos/pkg/capnslog/logmap.go:169 +0xba
  github.com/coreos/pkg/capnslog.SetGlobalLogLevel()
      /home/mischief/code/go/src/github.com/coreos/pkg/capnslog/logmap.go:136 +0x153
...
```