### PR TITLE
capnslog: use common function for formatted logging

### DIFF
--- a/capnslog/pkg_logger.go
+++ b/capnslog/pkg_logger.go
@@ -58,7 +58,7 @@ func (p *PackageLogger) Println(args ...interface{}) {
 }
 
 func (p *PackageLogger) Printf(format string, args ...interface{}) {
-	p.internalLog(calldepth, INFO, fmt.Sprintf(format, args...))
+	p.Logf(INFO, format, args...)
 }
 
 func (p *PackageLogger) Print(args ...interface{}) {
@@ -80,8 +80,7 @@ func (p *PackageLogger) Panic(args ...interface{}) {
 }
 
 func (p *PackageLogger) Fatalf(format string, args ...interface{}) {
-	s := fmt.Sprintf(format, args...)
-	p.internalLog(calldepth, CRITICAL, s)
+	p.Logf(CRITICAL, format, args...)
 	os.Exit(1)
 }
 
@@ -94,7 +93,7 @@ func (p *PackageLogger) Fatal(args ...interface{}) {
 // Error Functions
 
 func (p *PackageLogger) Errorf(format string, args ...interface{}) {
-	p.internalLog(calldepth, ERROR, fmt.Sprintf(format, args...))
+	p.Logf(ERROR, format, args...)
 }
 
 func (p *PackageLogger) Error(entries ...interface{}) {
@@ -104,7 +103,7 @@ func (p *PackageLogger) Error(entries ...interface{}) {
 // Warning Functions
 
 func (p *PackageLogger) Warningf(format string, args ...interface{}) {
-	p.internalLog(calldepth, WARNING, fmt.Sprintf(format, args...))
+	p.Logf(WARNING, format, args...)
 }
 
 func (p *PackageLogger) Warning(entries ...interface{}) {
@@ -114,7 +113,7 @@ func (p *PackageLogger) Warning(entries ...interface{}) {
 // Notice Functions
 
 func (p *PackageLogger) Noticef(format string, args ...interface{}) {
-	p.internalLog(calldepth, NOTICE, fmt.Sprintf(format, args...))
+	p.Logf(NOTICE, format, args...)
 }
 
 func (p *PackageLogger) Notice(entries ...interface{}) {
@@ -124,7 +123,7 @@ func (p *PackageLogger) Notice(entries ...interface{}) {
 // Info Functions
 
 func (p *PackageLogger) Infof(format string, args ...interface{}) {
-	p.internalLog(calldepth, INFO, fmt.Sprintf(format, args...))
+	p.Logf(INFO, format, args...)
 }
 
 func (p *PackageLogger) Info(entries ...interface{}) {
@@ -134,7 +133,7 @@ func (p *PackageLogger) Info(entries ...interface{}) {
 // Debug Functions
 
 func (p *PackageLogger) Debugf(format string, args ...interface{}) {
-	p.internalLog(calldepth, DEBUG, fmt.Sprintf(format, args...))
+	p.Logf(DEBUG, format, args...)
 }
 
 func (p *PackageLogger) Debug(entries ...interface{}) {
@@ -144,7 +143,7 @@ func (p *PackageLogger) Debug(entries ...interface{}) {
 // Trace Functions
 
 func (p *PackageLogger) Tracef(format string, args ...interface{}) {
-	p.internalLog(calldepth, TRACE, fmt.Sprintf(format, args...))
+	p.Logf(TRACE, format, args...)
 }
 
 func (p *PackageLogger) Trace(entries ...interface{}) {


### PR DESCRIPTION
Eliminate some unnecessary repetition