### PR TITLE
Offer the ability to pass through standard capnslog when embedding.

### DIFF
--- a/capnslog/formatters.go
+++ b/capnslog/formatters.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"log"
 	"runtime"
 	"strings"
 	"time"
@@ -103,4 +104,34 @@ func (c *PrettyFormatter) Format(pkg string, l LogLevel, depth int, entries ...i
 
 func (c *PrettyFormatter) Flush() {
 	c.w.Flush()
+}
+
+// LogFormatter emulates the form of the traditional built-in logger.
+type LogFormatter struct {
+	logger *log.Logger
+	prefix string
+}
+
+// NewLogFormatter is a helper to produce a new LogFormatter struct. It uses the
+// golang log package to actually do the logging work so that logs look similar.
+func NewLogFormatter(w io.Writer, prefix string, flag int) Formatter {
+	return &LogFormatter{
+		logger: log.New(w, "", flag), // don't use prefix here
+		prefix: prefix,               // save it instead
+	}
+}
+
+// Format builds a log message for the LogFormatter. The LogLevel is ignored.
+func (lf *LogFormatter) Format(pkg string, _ LogLevel, _ int, entries ...interface{}) {
+	str := fmt.Sprint(entries...)
+	prefix := lf.prefix
+	if pkg != "" {
+		prefix = fmt.Sprintf("%s%s: ", prefix, pkg)
+	}
+	lf.logger.Output(5, fmt.Sprintf("%s%v", prefix, str)) // call depth is 5
+}
+
+// Flush is included so that the interface is complete, but is a no-op.
+func (lf *LogFormatter) Flush() {
+	// noop
 }

--- a/capnslog/formatters.go
+++ b/capnslog/formatters.go
@@ -29,7 +29,7 @@ type Formatter interface {
 	Flush()
 }
 
-func NewStringFormatter(w io.Writer) *StringFormatter {
+func NewStringFormatter(w io.Writer) Formatter {
 	return &StringFormatter{
 		w: bufio.NewWriter(w),
 	}


### PR DESCRIPTION
This resolves: https://github.com/coreos/etcd/issues/4115