### PR TITLE
README: remove Semaphore badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 a collection of go utility packages
 
 [![Build Status](https://travis-ci.org/coreos/pkg.png?branch=master)](https://travis-ci.org/coreos/pkg)
-[![Build Status](https://semaphoreci.com/api/v1/projects/14b3f261-22c2-4f56-b1ff-f23f4aa03f5c/411991/badge.svg)](https://semaphoreci.com/coreos/pkg)
 [![Godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/coreos/pkg)


### PR DESCRIPTION
Switched to travis instead for now.