### PR TITLE
k8s-tlsutil: add k8s-tlsutil pkg

### DIFF
--- a/k8s-tlsutil/k8s-tlsutil.go
+++ b/k8s-tlsutil/k8s-tlsutil.go
@@ -1,0 +1,140 @@
+package k8stlsutil
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math"
+	"math/big"
+	"net"
+	"time"
+)
+
+const (
+	RSAKeySize   = 2048
+	Duration365d = time.Hour * 24 * 365
+)
+
+type CertConfig struct {
+	CommonName   string
+	Organization []string
+	AltNames     AltNames
+}
+
+// AltNames contains the domain names and IP addresses that will be added
+// to the API Server's x509 certificate SubAltNames field. The values will
+// be passed directly to the x509.Certificate object.
+type AltNames struct {
+	DNSNames []string
+	IPs      []net.IP
+}
+
+func NewPrivateKey() (*rsa.PrivateKey, error) {
+	return rsa.GenerateKey(rand.Reader, RSAKeySize)
+}
+
+func EncodePublicKeyPEM(key *rsa.PublicKey) ([]byte, error) {
+	der, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return []byte{}, err
+	}
+	block := pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: der,
+	}
+	return pem.EncodeToMemory(&block), nil
+}
+
+func EncodePrivateKeyPEM(key *rsa.PrivateKey) []byte {
+	block := pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	return pem.EncodeToMemory(&block)
+}
+
+func EncodeCertificatePEM(cert *x509.Certificate) []byte {
+	block := pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	}
+	return pem.EncodeToMemory(&block)
+}
+
+func NewSelfSignedCACertificate(cfg CertConfig, key *rsa.PrivateKey, validDuration time.Duration) (*x509.Certificate, error) {
+	now := time.Now()
+
+	dur := Duration365d * 10
+	if validDuration != 0 {
+		dur = validDuration
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber: new(big.Int).SetInt64(0),
+		Subject: pkix.Name{
+			CommonName:   cfg.CommonName,
+			Organization: cfg.Organization,
+		},
+		NotBefore:             now,
+		NotAfter:              now.Add(dur),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA: true,
+	}
+
+	certDERBytes, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, key.Public(), key)
+	if err != nil {
+		return nil, err
+	}
+	return x509.ParseCertificate(certDERBytes)
+}
+
+func ParsePEMEncodedCACert(pemdata []byte) (*x509.Certificate, error) {
+	decoded, _ := pem.Decode(pemdata)
+	if decoded == nil {
+		return nil, errors.New("no PEM data found")
+	}
+	return x509.ParseCertificate(decoded.Bytes)
+}
+
+func ParsePEMEncodedPrivateKey(pemdata []byte) (*rsa.PrivateKey, error) {
+	decoded, _ := pem.Decode(pemdata)
+	if decoded == nil {
+		return nil, errors.New("no PEM data found")
+	}
+	return x509.ParsePKCS1PrivateKey(decoded.Bytes)
+}
+
+func NewSignedCertificate(cfg CertConfig, key *rsa.PrivateKey, caCert *x509.Certificate, caKey *rsa.PrivateKey, validDuration time.Duration) (*x509.Certificate, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	if err != nil {
+		return nil, err
+	}
+
+	dur := Duration365d
+	if validDuration != 0 {
+		dur = validDuration
+	}
+
+	certTmpl := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:   cfg.CommonName,
+			Organization: caCert.Subject.Organization,
+		},
+		DNSNames:     cfg.AltNames.DNSNames,
+		IPAddresses:  cfg.AltNames.IPs,
+		SerialNumber: serial,
+		NotBefore:    caCert.NotBefore,
+		NotAfter:     time.Now().Add(dur),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	certDERBytes, err := x509.CreateCertificate(rand.Reader, &certTmpl, caCert, key.Public(), caKey)
+	if err != nil {
+		return nil, err
+	}
+	return x509.ParseCertificate(certDERBytes)
+}


### PR DESCRIPTION
pulls in some handy code from bootkube
https://github.com/coreos/bootkube/blob/master/pkg/tlsutil/tlsutil.go

Only change is to allow override of valid duration (still uses same defaults though).