### PR TITLE
capnslog: add Fatalln method

### DIFF
--- a/capnslog/pkg_logger.go
+++ b/capnslog/pkg_logger.go
@@ -92,6 +92,12 @@ func (p *PackageLogger) Fatal(args ...interface{}) {
 	os.Exit(1)
 }
 
+func (p *PackageLogger) Fatalln(args ...interface{}) {
+	s := fmt.Sprintln(args...)
+	p.internalLog(calldepth, CRITICAL, s)
+	os.Exit(1)
+}
+
 // Error Functions
 
 func (p *PackageLogger) Errorf(format string, args ...interface{}) {


### PR DESCRIPTION
I want to plug in capnslog for etcd clientv3 logger
to make it consistent with etcd package loggers.
And grpclog.Logger interface needs Fatalln method.