### PR TITLE
netutil: remove capnslog dependency

### DIFF
--- a/netutil/proxy.go
+++ b/netutil/proxy.go
@@ -2,15 +2,10 @@ package netutil
 
 import (
 	"io"
+	"log"
 	"net"
 	"sync"
 	"time"
-
-	"github.com/coreos/pkg/capnslog"
-)
-
-var (
-	log = capnslog.NewPackageLogger("github.com/coreos/pkg/netutil", "main")
 )
 
 // ProxyTCP proxies between two TCP connections.
@@ -30,9 +25,9 @@ func ProxyTCP(conn1, conn2 net.Conn, tlsWriteDeadline, tlsReadDeadline time.Dura
 
 func copyBytes(dst, src net.Conn, wg *sync.WaitGroup, writeDeadline, readDeadline time.Duration) {
 	defer wg.Done()
-	n, err := io.Copy(dst, src)
+	_, err := io.Copy(dst, src)
 	if err != nil {
-		log.Errorf("proxy i/o error: %v", err)
+		log.Printf("proxy i/o error: %v", err)
 	}
 
 	if cr, ok := src.(*net.TCPConn); ok {
@@ -50,6 +45,4 @@ func copyBytes(dst, src net.Conn, wg *sync.WaitGroup, writeDeadline, readDeadlin
 		rto := time.Now().Add(readDeadline)
 		dst.SetReadDeadline(rto)
 	}
-
-	log.Debugf("proxy copied %d bytes %s -> %s", n, src.RemoteAddr(), dst.RemoteAddr())
 }


### PR DESCRIPTION
This commit decouples netutil from capnslog, making it easier to
later deprecate it and to fix dependency loops between coreos/pkg
and coreos/go-systemd.

References:
 * https://github.com/coreos/pkg/issues/73#issuecomment-228034278
 * https://github.com/coreos/pkg/issues/57