### PR TITLE
capnslog: implement logrus.StdLogger

### DIFF
--- a/capnslog/pkg_logger.go
+++ b/capnslog/pkg_logger.go
@@ -81,6 +81,12 @@ func (p *PackageLogger) Panic(args ...interface{}) {
 	panic(s)
 }
 
+func (p *PackageLogger) Panicln(args ...interface{}) {
+	s := fmt.Sprintln(args...)
+	p.internalLog(calldepth, CRITICAL, s)
+	panic(s)
+}
+
 func (p *PackageLogger) Fatalf(format string, args ...interface{}) {
 	p.Logf(CRITICAL, format, args...)
 	os.Exit(1)


### PR DESCRIPTION
This commit adds a Panicln method to the PackageLogger to make it
implement all of the golang/log logging methods and thus making it
implement with the logrus.StdLogger interface. I want this so that Dex
can accept loggers from packages that use capnslog, notably bridge. This
is the only missing method to fulfil the interface.