### PR TITLE
flagutil: Replace dots in flags too

### DIFF
--- a/flagutil/env.go
+++ b/flagutil/env.go
@@ -20,7 +20,7 @@ func SetFlagsFromEnv(fs *flag.FlagSet, prefix string) (err error) {
 	})
 	fs.VisitAll(func(f *flag.Flag) {
 		if !alreadySet[f.Name] {
-			key := prefix + "_" + strings.ToUpper(strings.Replace(f.Name, "-", "_", -1))
+			key := prefix + "_" + strings.ToUpper(strings.Replace(strings.Replace(f.Name, ".", "_", -1), "-", "_", -1))
 			val := os.Getenv(key)
 			if val != "" {
 				if serr := fs.Set(f.Name, val); serr != nil {


### PR DESCRIPTION
This replaces dots in flags, so flags like `--web.metricspath` can be also configured using environment variables.