### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/capnslog/logmap.go
+++ b/capnslog/logmap.go
@@ -95,7 +95,7 @@ func (l *LogLevel) Set(s string) error {
 	return nil
 }
 
-// Returns an empty string, only here to fulfill the pflag.Value interface.
+// Type returns an empty string, only here to fulfill the pflag.Value interface.
 func (l *LogLevel) Type() string {
 	return ""
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from Effective Go. It’s admittedly a relatively minor fix up. Does this help you?